### PR TITLE
Remove hexchat from packages

### DIFF
--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -123,7 +123,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail hexchat htop keepassxc mlocate mpv noto-fonts-emoji ntfs-3g powerline-fonts rofi steam systray-x thunderbird timeshift tmux ttf-font-awesome virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc mlocate mpv noto-fonts-emoji ntfs-3g powerline-fonts rofi steam systray-x thunderbird timeshift tmux ttf-font-awesome virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
 paru -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer ssh-agent.service #Start and enable timers and services

--- a/Gentoo/i3.md
+++ b/Gentoo/i3.md
@@ -83,7 +83,6 @@ To enable flathub repo: `flatpak remote-add --if-not-exists flathub https://flat
 - xorg-xhost
 - flatpak
 - gnome-keyring
-- hexchat
 - keepassxc
 - mpv
 - gparted


### PR DESCRIPTION
I now use my self-hosted [The Lounge](https://thelounge.chat/) instance as my IRC client, so I don't need Hexchat anymore.
Additionnaly, Hexchat is now [unmaintained](https://hexchat.github.io/news/2.16.2.html).